### PR TITLE
Makefile fixes and generalization

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,8 +1,9 @@
 SRC = $(wildcard *.c)
 OBJ = $(SRC:.c=.o)
 DEP = $(OBJ:.o=.d)
+NCURSES = $(shell pkg-config --libs ncurses)
 CFLAGS = -Wall -g -Werror -std=gnu99 -pedantic -DNIX -DMULTIPLE_SCORE_ENTRY -DEXTRA
-LDFLAGS = -lm -lncurses
+LDFLAGS = -lm $(NCURSES)
 
 larn: $(OBJ)
 	$(CC) -o $@ $^ $(LDFLAGS)

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,7 +1,7 @@
 SRC = $(wildcard *.c)
 OBJ = $(SRC:.c=.o)
 DEP = $(OBJ:.o=.d)
-CFLAGS = -Wall -g -Werror -std=c99 -pedantic -DNIX -DMULTIPLE_SCORE_ENTRY -DEXTRA
+CFLAGS = -Wall -g -Werror -std=gnu99 -pedantic -DNIX -DMULTIPLE_SCORE_ENTRY -DEXTRA
 LDFLAGS = -lm -lncurses
 
 larn: $(OBJ)


### PR DESCRIPTION
On systems that separate ncurses into two libs, ncurses and tinfo, the hard coded `-lncurses` is insufficient and `strnlen` is a GNU extension that is not available with -std=c99.