### PR TITLE
fix: use bounded strlcpy/snprintf in scores.c

### DIFF
--- a/scores.c
+++ b/scores.c
@@ -640,7 +640,7 @@ new1sub (int score, int i, char *whoo, int taxes)
   p->taxes += taxes;
   if ((score >= p->score) || (c[HARDGAME] > p->hardlev))
     {
-      strcpy (p->who, whoo);
+      snprintf (p->who, sizeof (p->who), "%s", whoo);
       p->score = score;
       p->hardlev = c[HARDGAME];
       p->timeused = gtime / 100;
@@ -669,7 +669,7 @@ new2sub (int score, int i, char *whoo, int whyded)
   p = &sco[i];
   if ((score >= p->score) || (c[HARDGAME] > p->hardlev))
     {
-      strcpy (p->who, whoo);
+      snprintf (p->who, sizeof (p->who), "%s", whoo);
       p->score = score;
       p->what = whyded;
       p->hardlev = c[HARDGAME];
@@ -973,7 +973,7 @@ getplid (char *nam)
   if (havepid != -1)
     return (havepid);		/* already did it */
   lflush ();			/* flush any pending I/O */
-  sprintf (name, "%s\n", nam);	/* append a \n to name */
+  snprintf (name, sizeof (name), "%s\n", nam);	/* append a \n to name */
   if (lopen (playerids) < 0)	/* no file, make it */
     {
       fd7 = open(playerids, S_IWUSR);


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `scores.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `scores.c:643` |

**Description**: The score recording functions in scores.c use strcpy to copy the player name ('whoo') into a fixed-size destination buffer ('p->who') within the score record struct without any length validation. If the player name exceeds the size of the destination buffer, the copy operation overflows the buffer, corrupting adjacent stack or heap memory including return addresses and function pointers.

## Changes
- `scores.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
